### PR TITLE
Add the chat toggle action

### DIFF
--- a/src/TeamsMonitor.Core/TeamsSocket.cs
+++ b/src/TeamsMonitor.Core/TeamsSocket.cs
@@ -177,7 +177,7 @@ namespace TeamsMonitor.Core
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<int> ToggleChatAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-ui", cancellationToken);
+        public Task<int> ToggleChatAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-ui", cancellationToken, new { @Type = "chat" });
 
         /// <summary>
         /// 

--- a/src/TeamsMonitor.Core/TeamsSocket.cs
+++ b/src/TeamsMonitor.Core/TeamsSocket.cs
@@ -173,6 +173,13 @@ namespace TeamsMonitor.Core
         public Task<int> ToggleVideoAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-video", cancellationToken);
 
         /// <summary>
+        /// Toggle the Chat UI
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> ToggleChatAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-ui", cancellationToken);
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="disposing"></param>


### PR DESCRIPTION
While I was researching and reverse engineering the Microsoft Teams plugin of the Elgato Stream Deck, I noticed an action called `ToggleChat`:

```ts
// meetingController.js
TeamsMeetingController.prototype.toggleChat = function () {
    this.sendMeetingActionRequestToTeams("toggle-ui" /* ToggleUI */, "chat");
};
```

The `toggle-ui` action with the `chat` parameter toggles the chat window on the right side of a call window.