### PR TITLE
Added additional discovered commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ At first you have limited access, and once the user goes into a meeting you'll s
 }
 ```
 
-If `canPair` is `true`, it means the user is in a meeting and you can send any [available command](#commands-available) to trigger the pairing message in Teams and your app will get a new token for the next connection. If seeing if the user is an a meeting is enough for your use case, you can skip the pairing process and just use `canPair` as an indication whether the user is in a meeting.
+If `canPair` is `true`, it means the user is in a meeting and you can send the `pair` command (or any [available command](#commands-available) other than `query-state`) to trigger the pairing message in Teams. If the user approves the request your app will get a new token for the next connection. If seeing if the user is an a meeting is enough for your use case, you can skip the pairing process and just use `canPair` as an indication whether the user is in a meeting.
 
 ### Messages send by Teams
 
@@ -204,9 +204,16 @@ Each command has a `requestId` that you can use to match the response to the req
 { "action":"some-action","parameters":{},"requestId":1 }
 ```
 
+#### Pair
+```json
+{"action":"pair","parameters":{},"requestId":1}
+```
+
 #### Send a reaction
 
-You can send several reactions to teams. The once tested: `like`, `love`, `applause`, `wow`, `laugh`
+You can send several reactions to teams. 
+
+Verified types: `like`, `love`, `applause`, `wow`, `laugh`
 
 ```json
 {
@@ -224,10 +231,34 @@ You can send several reactions to teams. The once tested: `like`, `love`, `appla
 {"action":"toggle-background-blur","parameters":{},"requestId":1}
 ```
 
+#### Turn on background blur
+
+```json
+{"action":"blur-background", parameters:{}, "requestId":1}
+```
+
+#### Turn off background blur
+
+```json
+{"action":"unblur-background", parameters:{}, "requestId":1}
+```
+
 #### Toggle Video
   
 ```json
 {"action":"toggle-video","parameters":{},"requestId":1}
+```
+
+#### Show Video
+  
+```json
+{"action":"show-video","parameters":{},"requestId":1}
+```
+
+#### Hide Video
+  
+```json
+{"action":"hide-video","parameters":{},"requestId":1}
 ```
 
 #### Toggle Mute
@@ -236,16 +267,68 @@ You can send several reactions to teams. The once tested: `like`, `love`, `appla
 {"action":"toggle-mute","parameters":{},"requestId":1}
 ```
 
+#### Mute
+
+```json
+{"action":"mute","parameters":{},"requestId":1}
+```
+
+#### Unmute
+
+```json
+{"action":"unmute","parameters":{},"requestId":1}
+```
+
 #### Toggle Hand
 
 ```json
 {"action":"toggle-hand","parameters":{},"requestId":1}
 ```
 
+#### Raise Hand
+
+```json
+{"action":"raise-hand","parameters":{},"requestId":1}
+```
+
+#### Lower Hand
+
+```json
+{"action":"lower-hand","parameters":{},"requestId":1}
+```
+
+#### Stop screen sharing
+
+```json
+{"action":"stop-sharing","parameters":{},"requestId":1}
+```
+
+#### Toggle ui elements
+
+You can toggle open/closed a couple of ui elements. 
+
+Verified types: `chat`, `share-tray`
+```json
+{
+  "action": "toggle-ui",
+  "parameters": {
+    "type": "chat"
+  },
+  "requestId": 1
+}
+```
+
 #### Leave call
 
 ```json
 {"action":"leave-call","parameters":{},"requestId":2}
+```
+
+#### Query state
+You can manually request teams to provide a meeting update
+
+```json
+{"action":"query-state", parameters:{}, "requestId":1}
 ```
 
 ## Socials

--- a/src/TeamsMonitor.Core/TeamsSocket.cs
+++ b/src/TeamsMonitor.Core/TeamsSocket.cs
@@ -85,6 +85,14 @@ namespace TeamsMonitor.Core
         public async Task<int> SendReaction(string reaction, CancellationToken cancellationToken) => await CallServiceAsync("send-reaction", cancellationToken, new { @Type = reaction });
 
         /// <summary>
+        /// Send a toggle-ui request to Teams
+        /// </summary>
+        /// <param name="element">Any available element `chat`, `share-tray`</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        public async Task<int> SendToggleUi(string element, CancellationToken cancellationToken) => await CallServiceAsync("toggle-ui", cancellationToken, new { @Type = element });
+
+        /// <summary>
         /// Connect to Teams Client
         /// </summary>
         /// <param name="blocking">Blocking will only return when cancelled, not blocking will start listening in background</param>
@@ -145,6 +153,20 @@ namespace TeamsMonitor.Core
         public Task<int> ToggleBackgroundBlurAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-background-blur", cancellationToken);
 
         /// <summary>
+        /// Blur background
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> BlurBackgroundAsync(CancellationToken cancellationToken) => CallServiceAsync("blur-background", cancellationToken);
+
+        /// <summary>
+        /// Unblur background
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> UnblurBackgroundAsync(CancellationToken cancellationToken) => CallServiceAsync("unblur-background", cancellationToken);
+
+        /// <summary>
         /// Toggle mute
         /// </summary>
         /// <param name="cancellationToken"></param>
@@ -152,11 +174,39 @@ namespace TeamsMonitor.Core
         public Task<int> ToggleMuteAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-mute", cancellationToken);
 
         /// <summary>
+        /// Mute
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> MuteAsync(CancellationToken cancellationToken) => CallServiceAsync("mute", cancellationToken);
+
+        /// <summary>
+        /// Unmute
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> UnmuteAsync(CancellationToken cancellationToken) => CallServiceAsync("unmute", cancellationToken);
+
+        /// <summary>
         /// Toggle Raise hand
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task<int> ToggleRaiseHandAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-hand", cancellationToken);
+
+        /// <summary>
+        /// Raise hand
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> RaiseHandAsync(CancellationToken cancellationToken) => CallServiceAsync("raise-hand", cancellationToken);
+
+        /// <summary>
+        /// Lower hand
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> LowerHandAsync(CancellationToken cancellationToken) => CallServiceAsync("lower-hand", cancellationToken);
 
         /// <summary>
         /// Toggle recording
@@ -171,6 +221,56 @@ namespace TeamsMonitor.Core
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task<int> ToggleVideoAsync(CancellationToken cancellationToken) => CallServiceAsync("toggle-video", cancellationToken);
+
+        /// <summary>
+        /// Show Video
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> ShowVideoAsync(CancellationToken cancellationToken) => CallServiceAsync("show-video", cancellationToken);
+
+        /// <summary>
+        /// Hide Video
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> HideVideoAsync(CancellationToken cancellationToken) => CallServiceAsync("hide-video", cancellationToken);
+
+        /// <summary>
+        /// Toggle chat pane
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> ToggleChatAsync(CancellationToken cancellationToken) => SendToggleUi("chat", cancellationToken);
+
+        /// <summary>
+        /// Toggle share tray
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> ToggleShareTrayAsync(CancellationToken cancellationToken) => SendToggleUi("share-tray", cancellationToken);
+
+        /// <summary>
+        /// Stop screen sharing
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> StopSharingAsync(CancellationToken cancellationToken) => CallServiceAsync("stop-sharing", cancellationToken);
+
+        /// <summary>
+        /// Pair
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> PairAsync(CancellationToken cancellationToken) => CallServiceAsync("pair", cancellationToken);
+
+
+        /// <summary>
+        /// Query State
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> QueryStateAsync(CancellationToken cancellationToken) => CallServiceAsync("query-state", cancellationToken);
 
         /// <summary>
         /// 


### PR DESCRIPTION
While working on a [project to control teams via Hammerspoon](https://github.com/asp55/MSTeams.spoon) (and looking at the strings defined in the Microsoft Teams app) I discovered additional available actions:

- query-state
- pair
- mute
- unmute
- show-video
- hide-video
- stop-sharing
- blur-background
- unblur-background
- raise-hand
- lower-hand
- toggle-ui (Requires type parameter, either `chat` or `share-tray`)

Your documentation of the Teams WebSocket API was essential to my project, so I'm contributing these discoveries back.

